### PR TITLE
ci: deploy após atualização da main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
-name: Deploy to VPS on Tag
+name: Deploy to VPS
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*.*.*"
       - "release-*"


### PR DESCRIPTION
## Resumo
- dispara o workflow de produção em pushes na branch `main`, incluindo merges de PR
- mantém os gatilhos existentes por tags `v*.*.*` e `release-*`
- atualiza o nome do workflow para refletir os dois modos de deploy

## Validação
- YAML do workflow validado localmente
- `git diff --check` sem erros