### PR TITLE
fix: corrige cache do pnpm no deploy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 allowBuilds:
   esbuild: true
   puppeteer: true


### PR DESCRIPTION
## Causa
O deploy falhou no passo `actions/setup-node` porque o pnpm 9 exige o campo `packages` no `pnpm-workspace.yaml` para resolver o store usado pelo cache.

## Correção
- registra a raiz do repositório como pacote do workspace
- mantém as permissões de build para esbuild, Puppeteer e Sharp

## Validação
- `npx --yes pnpm@9.15.9 store path --silent`
- `pnpm build`
- Astro check: 0 erros e 0 avisos